### PR TITLE
volcheck fix

### DIFF
--- a/source/objects/VolCheck.gml
+++ b/source/objects/VolCheck.gml
@@ -61,7 +61,10 @@ if (global.key_pressed[key_jump] && !fade) {
 
 if (fade) {
     alpha=min(1.5,alpha+1/room_speed)
-    if (alpha=1.5) room_goto_next()
+    if (alpha==1.5) {
+        settings("musvol",settings("sfxvol"))
+        room_goto_next()
+    }
 }
 #define Other_4
 /*"/*'/**//* YYD ACTION


### PR DESCRIPTION
musvol gets saved only the exact moment you start the fadeout, while you are still able to change sfxvol during that fadeout. This allows desyncing the two volume settings.
Being able to adjust either volume in the fadeout could be considered unintended, but I like the convenience of being able to still adjust the volume if you Shift to early.