### PR TITLE
fix stray inst_activate_around_player when paused

### DIFF
--- a/source/objects/Player.gml
+++ b/source/objects/Player.gml
@@ -712,7 +712,7 @@ applies_to=self
 //this is necessary because the player can't
 //follow platforms during standstill frames
 
-move_player(x,y+vsplatform,1)
+if (!global.pause) move_player(x,y+vsplatform,1)
 /*"/*'/**//* YYD ACTION
 lib_id=1
 action_id=424


### PR DESCRIPTION
Player -> End Step -> if !updating -> 9. follow platforms correctly -> calls move_player( , , 1) -> calls move_player_object -> calls instance_activate_around_player.
This means pausing the game runs activate_around_player every frame, unpausing some instances, leading to cases such as the attached video.
The PR assumes the end step action is only meant for delta time means, and as such it should simply not run when paused.

https://user-images.githubusercontent.com/53627487/187086311-8647cd0c-0623-4087-8ee5-91a437f2208c.mp4