### PR TITLE
disallow suicide in cutscenes

### DIFF
--- a/source/objects/Player.gml
+++ b/source/objects/Player.gml
@@ -344,6 +344,9 @@ if (!frozen) {
         if (key_released[key_jump]) {
             if (vspeed*vflip<0) vspeed*=0.45
         }
+        if (key_pressed[key_die]) {
+            kill_player()
+        }
     }
 }
 /*"/*'/**//* YYD ACTION

--- a/source/scripts/system_hotkeys.gml
+++ b/source/scripts/system_hotkeys.gml
@@ -2,7 +2,7 @@
 
 if (room!=global.difficulty_room) {
     //die key
-    if (global.key_pressed[key_die]) {
+    if (global.key_pressed[key_die] && !cutscene) {
         kill_player()
     }
 

--- a/source/scripts/system_hotkeys.gml
+++ b/source/scripts/system_hotkeys.gml
@@ -1,11 +1,6 @@
 //most engine hotkeys are handled here
 
 if (room!=global.difficulty_room) {
-    //die key
-    if (global.key_pressed[key_die] && !cutscene) {
-        kill_player()
-    }
-
     //restart
     if (global.key_pressed[key_restart]) {
         if (is_ingame() && !global.pause) {


### PR DESCRIPTION
The true motivation for this is that suiciding while riding Yoshi is currently notably busted, and vehicles use the cutscene system.
Since there is no universal kill_vehicle analogue, suicide should probably be reimplemented per vehicle if considered necessary? (Is there a notable reason why q is a system hotkey and not part of Player?)