### PR TITLE
"Fake" Coyote Time variant

### DIFF
--- a/source/objects/Player.gml
+++ b/source/objects/Player.gml
@@ -341,7 +341,7 @@ if (!frozen) {
         }
     }
 
-    if (coyoteTime!=0) vspeed-=gravity
+    if (coyoteTime!=0&&global.true_coyote_time==true) vspeed-=gravity
 
     if (vflip==-1) vspeed=max(-maxVspeed,vspeed)
     else if (vflip==1) vspeed=min(vspeed,maxVspeed)

--- a/source/scripts/engine_settings.gml
+++ b/source/scripts/engine_settings.gml
@@ -118,6 +118,9 @@
     //time in frames to allow single jumping after leaving a surface
     //turn this off for a precision needle game
     global.coyote_time=0
+    //changes whether the player is still affected by gravity in coyote time
+    //dependent on the value above
+    global.true_coyote_time=false
     //time in frames to allow jumping when the button is pressed too early in the air
     //makes 4.5s easier
     global.jump_buffering=0

--- a/source/scripts/index.yyd
+++ b/source/scripts/index.yyd
@@ -229,3 +229,4 @@ split_object
 
 timeline_miku_front
 savedatap
+str_cat

--- a/source/scripts/index.yyd
+++ b/source/scripts/index.yyd
@@ -229,4 +229,3 @@ split_object
 
 timeline_miku_front
 savedatap
-str_cat

--- a/source/scripts/player_jump.gml
+++ b/source/scripts/player_jump.gml
@@ -11,7 +11,7 @@ if (vvvvvv) {
         jump_timer=0
     }
 } else if (!hang) {
-    if (on_ground() || instance_place(x,y+vflip,Water1) || instance_place(x,y+vflip,PlatformWater) || instance_place(x,y+vflip,GuyWater) || ladderjump) {
+    if (on_ground() || instance_place(x,y+vflip,Water1) || instance_place(x,y+vflip,PlatformWater) || instance_place(x,y+vflip,GuyWater) || ladderjump || (global.true_coyote_time==false&&coyoteTime!=0) ) {
         //floor jump
         vspeed=-jump*vflip
         if (global.use_momentum_values) {


### PR DESCRIPTION
Found out that not performing gravity calculations while coyote time is active, may not be a desirable behavior. This change allows for a softer variant of coyote time to be active, where gravity is still applied, but you keep your first jump as well.