### PR TITLE
Make "medium" the default difficulty

### DIFF
--- a/source/scripts/engine_settings.gml
+++ b/source/scripts/engine_settings.gml
@@ -49,8 +49,8 @@ global.release_mode=false
 
 //difficulties
     //difficulty options:
-    add_difficulty("Medium",false,false)
-    add_difficulty("Hard",true,false)
+    add_difficulty("Medium",true,false)
+    add_difficulty("Hard",false,false)
     add_difficulty("Very Hard",false,false)
     add_difficulty("Impossible",false,true)
 


### PR DESCRIPTION
99% of fangames are built around medium. This setting has just been tricking players into playing on the wrong difficulty for new releases.