### PR TITLE
Remove redundant depth fields

### DIFF
--- a/source/objects/AnyWater.gml
+++ b/source/objects/AnyWater.gml
@@ -12,7 +12,6 @@ action_id=603
 applies_to=self
 */
 //field surface: false - wavy water surface
-//field depth: number
 
 if (surface) {
     with (instance_create(x,y,WaterSurface)) {

--- a/source/objects/Autotiler.gml
+++ b/source/objects/Autotiler.gml
@@ -25,7 +25,6 @@ When using "clone" mode, place the desired tile underneath the object.
 //field type: enum("border","grass","pipes","clone","clone scale","extended") - default grass
 //field tileset: background
 //field grid - default 32
-//field depth - default 1000
 //field solid_border: false
 
 if (persistent) {

--- a/source/objects/Autotiler.txt
+++ b/source/objects/Autotiler.txt
@@ -2,6 +2,6 @@ sprite=sprThrow
 visible=1
 solid=0
 persistent=0
-depth=999
+depth=1000
 parent=ActiveIngame
 mask=

--- a/source/objects/CherryBounce.gml
+++ b/source/objects/CherryBounce.gml
@@ -32,4 +32,3 @@ applies_to=self
 //field hspeed: number
 //field vspeed: number
 //field gravity: number
-//field depth: number

--- a/source/objects/DepthBlender.gml
+++ b/source/objects/DepthBlender.gml
@@ -16,7 +16,6 @@ lib_id=1
 action_id=603
 applies_to=self
 */
-//field depth: number
 //field blend_mode: enum(bm_normal,bm_add,bm_subtract,bm_max)
 //field blend_mode_ext_source: enum(bm_zero,bm_one,bm_src_color,bm_inv_src_color,bm_src_alpha,bm_inv_src_alpha,bm_dest_alpha,bm_inv_dest_alpha,bm_dest_color,bm_inv_dest_color,bm_src_alpha_sat)
 //field blend_mode_ext_dest: enum(bm_zero,bm_one,bm_src_color,bm_inv_src_color,bm_src_alpha,bm_inv_src_alpha,bm_dest_alpha,bm_inv_dest_alpha,bm_dest_color,bm_inv_dest_color,bm_src_alpha_sat)

--- a/source/objects/DepthHueShift.gml
+++ b/source/objects/DepthHueShift.gml
@@ -11,11 +11,9 @@ lib_id=1
 action_id=603
 applies_to=self
 */
-//field depth: number
 //field amount: angle
 
 /*preview
-    depth=Field("depth")
     shader_pixel_set(ShaderFromPack("ps2_hueshift"))
     shader_pixel_uniform_f("amount",Field("amount")/360)
 */

--- a/source/objects/DepthRainbow.gml
+++ b/source/objects/DepthRainbow.gml
@@ -11,10 +11,7 @@ lib_id=1
 action_id=603
 applies_to=self
 */
-//field depth: number
-
 /*preview
-    depth=Field("depth")
     shader_vertex_set_passthrough()
     shader_pixel_set(ShaderFromPack("ps3_rainbow"))
 */

--- a/source/objects/DepthShaderReset.gml
+++ b/source/objects/DepthShaderReset.gml
@@ -4,12 +4,10 @@ lib_id=1
 action_id=603
 applies_to=self
 */
-//field depth: number
 /*desc
     Turns off any shader effects at its depth.
 */
 /*preview
-    depth=Field("depth")
     shader_reset()
 */
 #define Draw_0

--- a/source/objects/DepthTint.gml
+++ b/source/objects/DepthTint.gml
@@ -12,14 +12,12 @@ lib_id=1
 action_id=603
 applies_to=self
 */
-//field depth: number
 //field color: color
 //field amount: number(0,100)
 /*desc
     Applies a tint effect to a desired color.
 */
 /*preview
-    depth=Field("depth")
     shader_pixel_set(ShaderFromPack("ps2_tint"))
     shader_pixel_uniform_color("colorto",Field("color"))
     shader_pixel_uniform_f("amount",saturate(Field("amount")/100))

--- a/source/objects/DotKiller.gml
+++ b/source/objects/DotKiller.gml
@@ -1,7 +1,0 @@
-#define Other_4
-/*"/*'/**//* YYD ACTION
-lib_id=1
-action_id=603
-applies_to=self
-*/
-//field depth: number

--- a/source/objects/DropShadow.gml
+++ b/source/objects/DropShadow.gml
@@ -14,7 +14,6 @@ lib_id=1
 action_id=603
 applies_to=self
 */
-//field depth: number
 #define Draw_0
 /*"/*'/**//* YYD ACTION
 lib_id=1

--- a/source/objects/Gizmo.gml
+++ b/source/objects/Gizmo.gml
@@ -217,7 +217,6 @@ applies_to=self
 */
 ///fields definition
 
-//field depth: number
 //field sound: string
 //field movement: false
     //field dir: angle

--- a/source/objects/PlayerKiller.gml
+++ b/source/objects/PlayerKiller.gml
@@ -1,7 +1,0 @@
-#define Other_4
-/*"/*'/**//* YYD ACTION
-lib_id=1
-action_id=603
-applies_to=self
-*/
-//field depth: number

--- a/source/objects/PlayerKillerActive.gml
+++ b/source/objects/PlayerKillerActive.gml
@@ -11,4 +11,4 @@ lib_id=1
 action_id=603
 applies_to=self
 */
-//field depth: number
+//field active: true

--- a/source/objects/ShapeWater.gml
+++ b/source/objects/ShapeWater.gml
@@ -25,7 +25,6 @@ applies_to=self
 */
 //field sprite_index: sprite
 //field image_speed: number
-//field depth: number
 //field water_type: enum("Water1","Water2","Water3","CatharsisWater")
 
 switch (water_type) {


### PR DESCRIPTION
Since this is now a "default" field in gm82room, it makes sense to remove from existing objects and reduce clutter in the editor.